### PR TITLE
Fixed most memory leaks

### DIFF
--- a/main.v
+++ b/main.v
@@ -1,15 +1,27 @@
 import time
 
+const (
+	OFFSET = '    '
+	CELL_LIVE = '@'
+	CELL_DEAD = '.'
+)
+
 fn print_field(field[]array_int) {
+	mut s := new_string_builder(0)
 	for line in field {
-		mut s := '    '
+		s.write(OFFSET)
 		for j, cell in line {
 			if j == 0 || j == line.len - 1{continue}
-			s += if cell == 1{'@'} else { '.'}
+			if cell == 1 {
+				s.write(CELL_LIVE)
+			} else {
+				s.write(CELL_DEAD)
+			}
 		}
-		println(s)
+		s.writeln('')
 	}
-	println('')
+	println(s.str())
+	s.free()
 }
 
 pub fn gun() []array_int {
@@ -71,6 +83,10 @@ fn main() {
 				}
 			}
 		}
+		for i := 0; i < field.len; i++ {
+			field[i].free()
+		}
+		free(field.data)
 		field = new_field
 		print_field(field)
 		time.sleep_ms(100)


### PR DESCRIPTION
`timeout 5s valgrind ./main` 
Before: 
``` 
LEAK SUMMARY:
definitely lost: 736,240 bytes in 29,065 blocks
indirectly lost: 107,184 bytes in 638 blocks
possibly lost: 0 bytes in 0 blocks
still reachable: 21,727 bytes in 97 blocks
suppressed: 0 bytes in 0 blocks
```
After: 
``` 
LEAK SUMMARY:
definitely lost: 10,200 bytes in 1,330 blocks
indirectly lost: 0 bytes in 0 blocks
possibly lost: 0 bytes in 0 blocks
still reachable: 16,087 bytes in 67 blocks
suppressed: 0 bytes in 0 blocks
```